### PR TITLE
Update package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "husky": "^3.1.0",
-    "lint-staged": "^9.5.0",
-    "prettier": "^1.19.1",
+    "husky": "^4.2.5",
+    "lint-staged": "^10.2.11",
+    "prettier": "^2.0.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "3.2.0"
+    "react-scripts": "3.4.1"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -44,6 +44,6 @@
     ]
   },
   "devDependencies": {
-    "cypress": "^3.8.1"
+    "cypress": "^4.11.0"
   }
 }


### PR DESCRIPTION
Broadly, this is for security fixes & performance improvements. Upgrading to Cypress v4.x also gives us access to testing in other browsers, like Firefox – great for making sure we're not too focused on Chromium!

I removed `git add` from `lint-staged` because it's redundant as of v10.