### PR TITLE
Add recap section to ORIENTATION file

### DIFF
--- a/ORIENTATION.md
+++ b/ORIENTATION.md
@@ -124,6 +124,4 @@ Whew, that was a lot, right? There’s a good chance (💯%) we’re forgetting 
 
 ![Photo of programmer Margaret Hamilton standing next to the navigation software that she and her MIT team produced for the Apollo Project.](./_resources/images/Margaret_Hamilton.gif)
 
----
-
 

--- a/ORIENTATION.md
+++ b/ORIENTATION.md
@@ -113,11 +113,11 @@ Whew, that was a lot, right? There’s a good chance (💯%) we’re forgetting 
 **Let's run through a quick, high-level recap of what your time at The Collab Lab will look like:** 
 
 * During your time at The Collab Lab, you’ll gain experience working on a software team, led by people in the industry, on a project structured in a way very close to what you’d see at many companies.
-* We will spend 8 weeks working together to build a smart shopping list app. [See a demo of the same app that a previous team built here](https://www.youtube.com/watch?v=uWgkwY_VBPo&feature=youtu.be).
+* We will spend 8 weeks working together to build a smart shopping list app. See a demo of the same app that a previous team built [here](https://www.youtube.com/watch?v=uWgkwY_VBPo&feature=youtu.be).
 * Collab Lab teams consist of 4 developers, 2 mentors, and 1 assistant mentor.
 * Each week, the team’s developers will break up into 2 pairs. Each pair will tackle a single issue from the project board in the team’s GitHub repo.
 * Developers will each spend about 5 hours per week working on the project. These hours include pair programming with weekly partners, researching, working with partner asynchronously on issues, creating pull requests, and doing code reviews.
-* Each Sunday during the program, the team will have a Weekly Sync where developers demo the feature they built in the previous week and a mentor lead a learning module or the team participate in a retrospective.
+* Each Sunday during the program, the team will have a Weekly Sync where developers will demo the feature they built in the previous week and a mentor will lead a learning module or the team participate in a retrospective.
 * **What’s next?:** Your team will kick off the project with your first weekly sync on {COHORT START DATE}
 
 ### Let's Do This!

--- a/ORIENTATION.md
+++ b/ORIENTATION.md
@@ -106,10 +106,24 @@ If you’re not already super familiar with Slack, no worries! Here are a couple
 
 **Note:** You can disable the animation of gifs and emojus in the Slack app itself. Visit [the Slack Help Center](https://slack.com/help/articles/228023907-Manage-animated-images-and-emoji) to learn more.
 
-### What else?
+### Let's recap!
 
-There’s a good chance (💯%) we’re forgetting or glossing over something important, so please be noisy on Slack as things come up. We will do our best to get you unstuck. Also, lean on each other for help as well! Finally, work in the open so everyone can benefit from your questions.
+Whew, that was a lot, right? There’s a good chance (💯%) we’re forgetting or glossing over something important, so please be noisy on Slack as things come up. We will do our best to get you unstuck. Also, lean on each other for help as well! Finally, work in the open so everyone can benefit from your questions.
+
+**Let's run through a quick, high-level recap of what your time at The Collab Lab will look like:** 
+
+* During your time at The Collab Lab, you’ll gain experience working on a software team, led by people in the industry, on a project structured in a way very close to what you’d see at many companies.
+* We will spend 8 weeks working together to build a smart shopping list app. [See a demo of the same app that a previous team built here](https://www.youtube.com/watch?v=uWgkwY_VBPo&feature=youtu.be).
+* Collab Lab teams consist of 4 developers, 2 mentors, and 1 assistant mentor.
+* Each week, the team’s developers will break up into 2 pairs. Each pair will tackle a single issue from the project board in the team’s GitHub repo.
+* Developers will each spend about 5 hours per week working on the project. These hours include pair programming with weekly partners, researching, working with partner asynchronously on issues, creating pull requests, and doing code reviews.
+* Each Sunday during the program, the team will have a Weekly Sync where developers demo the feature they built in the previous week and a mentor lead a learning module or the team participate in a retrospective.
+* **What’s next?:** Your team will kick off the project with your first weekly sync on {COHORT START DATE}
 
 ### Let's Do This!
 
 ![Photo of programmer Margaret Hamilton standing next to the navigation software that she and her MIT team produced for the Apollo Project.](./_resources/images/Margaret_Hamilton.gif)
+
+---
+
+


### PR DESCRIPTION
|     | Type                       |
| --- | -------------------------- |
|  ✓ | :sparkles: New feature     |

## Description

This PR adds the idea of a recap to the `ORIENTATION` doc. 

I have found that any time I have run orientation, I end up giving a quick, high-level recap because there is just so much new info and it can be a little overwhelming for new Collabies. My idea here is to solidify that recap so that anyone running the end of an Orientation has a solid outline for making the new Collabies feel at ease and better wrap their minds around what their time at the Collab Lab will look like. 

## Acceptance Criteria

The `ORIENTATION` file gives a good high-level look at what a Collabie can expect their time at The Collab Lab to look like. 

## For reviewers

_**NOTE:** Everything that currently exists in this `ORIENTATION` doc is from the old `PROJECT BRIEF`. It all needs a little love. This PR is **ONLY** the addition of a recap section, which I was kind of using as a way to solidify the outline of how the `ORIENTATION` might go. So, you can/should ignore the rest of the `ORIENTATION` doc (unless you wanna go make notes in Slack, a fresh PR, or a Github issue about things you specifically want to update.)_ 

When you're looking at this new recap, think: 
* If I were to explain how Collab Lab works in a few bullets, what are the most important pieces to cover? 
* What things have new Collabies walked away from orientation confused about 
  * _Example: I've heard folks say they were fuzzy on when they'd be pair programming and the fact that they share an issue with their partner, rather than completing one issue each._

