### PR TITLE
Standardize data point

### DIFF
--- a/ORIENTACIÓN-es.md
+++ b/ORIENTACIÓN-es.md
@@ -19,7 +19,7 @@ Cuando se unen nuevxs devs y mentores a la comunidad de The Collab Lab, se unen 
 
 Saber escribir codigo es solo un aspecto de ser un dev profesional. Otro aspecto super important es saber como colaborar efectivamente en un equipo de desarollo de software. Ahí es donde The Collab Lab te puede ayudar!
 
-### Pair Programming/Programación en pares:
+### Programación en pares:
 
 Una parte de tus horas cada semana estaras [programando con tu pareja de equipo](https://www.microverse.org/blog/how-remote-pair-programming-works-and-why-it-can-change-your-life) - aqui es donde la colaboración más magica ocurre.
 
@@ -85,13 +85,13 @@ git checkout -b an-example-feature-branch
 git push -u origin an-example-feature-branch
 ```
 
-Cuando tu y tu pareja de trabajo tengan codigo funcional y creen que esta listo para mergearlo con main y deployear, seguiran estos pasos:
+Cuando tu y tu pareja de trabajo tengan codigo funcional y creen que esta listo para mergearlo con `main` y deployear, seguiran estos pasos:
 
 1. Crea un “[pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)” PR
 2. Avisale al otro equipo de pares en Slack que tienen un nuevo PR para revisar
 3. Incorpora el feedback del otro equipo en tu trabajo hasta que todes estan satisfechos que el codigo está listo para mergear
 4. Pedele un code review a una de las mentoras
-5. Ya aprobado, mergea el PR a main. (Tu codigo hace el build y se deploya a produccion automáticamente usando [Netlify](https://www.netlify.com/)
+5. Ya aprobado, mergea el PR a `main`. (Tu codigo hace el build y se deploya a produccion automáticamente usando [Netlify](https://www.netlify.com/)
 6. Revisa tu trabajo en [producción]({PRODUCTION_URL})
 7. Celebra!
 

--- a/ORIENTACIÓN-es.md
+++ b/ORIENTACIÓN-es.md
@@ -1,6 +1,7 @@
 # The Collab Lab Orientación
 
 ## ¿Qué es The Collab Lab?
+
 The Collab Lab existe para ayudar a ingenierxs recien empezando sus careras ganar experiencia trabajando colaborativamente con otrxs en un equipo de desarollo de software. Trabajamos remotamente en proyectos reales con otrxs ingenierxs recien empezando sus careras.
 
 La meta del proyecto es trabajar juntxs para crear una lista de mercado “inteligente” que aprende tus habitos al comprar mercado, colocando las cosas que seguramente vas a necesitar pronto al principio de tu lista de mercado.
@@ -11,12 +12,15 @@ Mira este video demo del equipo #6:
 [![TCL Demo Video Screenshot](_resources/images/TCLDemoReadmePic.png)](https://youtu.be/uWgkwY_VBPo)
 
 ## ¿Con quien trabajaré?
+
 Cuando se unen nuevxs devs y mentores a la comunidad de The Collab Lab, se unen a un grupo de amigxs talentosxs y brillantes al rededor del mundo. Cada 3 meses, empieza un nuevo “cohort” que consiste de varios equipos organizados por regiones. Estos equipos son compuestos de 4 devs quienes colaboran para crea una app propia y 3 mentoras quienes les apoyan en el proceso.
 
 ## ¿Porqué hacemos lo que hacemos?
+
 Saber escribir codigo es solo un aspecto de ser un dev profesional. Otro aspecto super important es saber como colaborar efectivamente en un equipo de desarollo de software. Ahí es donde The Collab Lab te puede ayudar!
 
 ### Pair Programming/Programación en pares:
+
 Una parte de tus horas cada semana estaras [programando con tu pareja de equipo](https://www.microverse.org/blog/how-remote-pair-programming-works-and-why-it-can-change-your-life) - aqui es donde la colaboración más magica ocurre.
 
 Programar en pares trae unas oportunidades muy emocionantes de enseñar y aprender de tu pareja, ver otra perspectiva y/o visión de los retos que estan enfrentando y avanzar en las metas compartidas.
@@ -24,38 +28,44 @@ Programar en pares trae unas oportunidades muy emocionantes de enseñar y aprend
 No hay una sola manera de programar en pares, pero en general te encuentras con tu pareja por Zoom y trabajaran la historia de usuario o tarea de la semana. Animate a probar maneras distintas de programar juntxs para ver que les va mejor acorde a sus estilos de colaboración.
 
 ## ¿Como funciona todo?
-El proyecto está organizado en GitHub como un set de [historias de usuario](https://www.mountaingoatsoftware.com/agile/user-stories), cada una con una descripción de la funcionalidad deseada, y tambien con [los criterios de aceptación](https://www.leadingagile.com/2014/09/acceptance-criteria/) que describen como saber si la tarea o la historia estan listos. Puedes encontrar las historias de usuario en [el board del proyecto] en GitHub. Esta colección de historias de usuario se llama el “backlog” y representa el trabajo necesario para terminar el proyecto.
+
+El proyecto está organizado en GitHub como un set de [historias de usuario](https://www.mountaingoatsoftware.com/agile/user-stories), cada una con una descripción de la funcionalidad deseada, y tambien con [los criterios de aceptación](https://www.leadingagile.com/2014/09/acceptance-criteria/) que describen como saber si la tarea o la historia estan listos. Puedes encontrar las historias de usuario en [el board del proyecto]({PROJECT_BOARD_URL}) en GitHub. Esta colección de historias de usuario se llama el “backlog” y representa el trabajo necesario para terminar el proyecto.
 
 Una tarea o historia está “lista”/”done” cuando lo siguente está implementado:
+
 - Los criterios de aceptación han sido satisfechos
 - Si es un feature de UI, ha sido revisada por [accesibilidad](https://accessibilityinsights.io/)
 - El codigo ha sido revisado y aprovado por el otro par de devs
-- El [Product Owner](https://www.agilealliance.org/glossary/product-owner/) (una de las mentoras) ha aceptado el trabajo y satisface los requerimientos 
+- El [Product Owner](https://www.agilealliance.org/glossary/product-owner/) (una de las mentoras) ha aceptado el trabajo y satisface los requerimientos
 
 Cada semana, el equipo de divide en pares y cada par es responsable de completar una historia del backlog.
 
 Al final de las 8 semanas de proyecto, todas las historias estaran completas y tendremos una hermosa app que el equipo ha creado colaborativamente!
 
 ### Coordination y comunicación
+
 Es super util para ti y tambien para tus mentores que documentes tu trabajo. Esto puede prevenir que pierdas el hilo con los detalles del trabajo o de decisiones que tomaste con tu pareja de trabajo. Esto tambien ayuda a tus mentoras tener contexto de tu progreso cuando pides ayuda.
 
 Una de las primeras cosas que tu y tu pareja de trabajo deberian hacer cada semana es crear [un PR borrador (draft PR)](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) para tu trabajo. Esto las permitira tener una conversacion sobre el trabajo al lado del code. Cuando haces esto y lo juntas con preguntas y conversaciones sobre la estrategia de implementacion de la tarea, tienes una manera muy linda de documentar tu progreso mientras trabajas.
 
 ### Slack
+
 La mayoria de nuestras coordinación de equipo sucede en el slack de [The Collab Lab](https://the-collab-lab.slack.com/) y en particular, en el canal de tu equipo.
 
 Si no estas familiarizada con Slack, no te preocupes! Aqui van algunos tips que te pueden ayudar a manejarlo como una pro!
+
 1. Hilos, hilos, hilos! No en serio, hilos! Los hilos son geniales porque cumplen 2 funciones muy bien:
-    - Encapsulan conversaciónes tal que en el futuro puedas encontrar la pregunta y la respuesta en el mismo lugar
-    -  Mantienen las notificaciones a un minimo, dandole a tus compañeras la opcion de seguir la conversacion o no
-2. Hablando de notificaciones, taggea gente cuando necesitas su atencion. “@stacie, puedes revisar este PR?” es mejor que “Alguien puede revisar este PR?” porque la segunda puede que no sea vista en mucho tiempo dependiendo de la configuración de notificaciones de la persona. Si necesitas la atencion de todo el canal, usa @here. Tambien tenemos grupos configurados como @group-tcl-19 y @group-tcl-9-mentors para taggear equipos enteros. Usalos!
+   - Encapsulan conversaciónes tal que en el futuro puedas encontrar la pregunta y la respuesta en el mismo lugar
+   - Mantienen las notificaciones a un minimo, dandole a tus compañeras la opcion de seguir la conversacion o no
+2. Hablando de notificaciones, taggea gente cuando necesitas su atencion. “`@stacie`, puedes revisar este PR?” es mejor que “Alguien puede revisar este PR?” porque la segunda puede que no sea vista en mucho tiempo dependiendo de la configuración de notificaciones de la persona. Si necesitas la atencion de todo el canal, usa `@here`. Tambien tenemos grupos configurados como `@group-tcl-19` y `@group-tcl-9-mentors` para taggear equipos enteros. Usalos!
 3. Usa GIFs y emojis libremente! La comunicación via texto puede leerse aburrido. No temas comunicarte con un poco de emocion cuando hagas esa pregunta de hook en React!
 
 Nota: puedes deshabilitar las animaciones de gifs y emoji en la app de Slack. Ve al [Slack Help Center](https://slack.com/help/articles/228023907-Manage-animated-images-and-emoji) para aprender más.
 
 ### Proceso de desarollo
- El trabajo se hará en ramas de features en git. Las ramas deben ser llamadas siguiendo esta convencion:
- 
+
+El trabajo se hará en ramas de features en git. Las ramas deben ser llamadas siguiendo esta convencion:
+
 ```
 <iniciales de persona 1><iniciales de persona 2><descripción corta>
 ```
@@ -76,28 +86,34 @@ git push -u origin an-example-feature-branch
 ```
 
 Cuando tu y tu pareja de trabajo tengan codigo funcional y creen que esta listo para mergearlo con main y deployear, seguiran estos pasos:
+
 1. Crea un “[pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)” PR
 2. Avisale al otro equipo de pares en Slack que tienen un nuevo PR para revisar
 3. Incorpora el feedback del otro equipo en tu trabajo hasta que todes estan satisfechos que el codigo está listo para mergear
 4. Pedele un code review a una de las mentoras
 5. Ya aprobado, mergea el PR a main. (Tu codigo hace el build y se deploya a produccion automáticamente usando [Netlify](https://www.netlify.com/)
-6. Revisa tu trabajo en producción
+6. Revisa tu trabajo en [producción]({PRODUCTION_URL})
 7. Celebra!
 
 ## ¿Cuándo sucede todo?
+
 El proyecto debe tomar alrededor de 40 horas en total durante 8 semanas. Eso nos dejaría más o menos 5 horas por semana. Al menos 2-3 horas de ese tiempo será destinado a hacer pair programming con tu pareja, 1 hora destinada para los Weekly Syncs y el resto del tiempo, deberás estar investigando, haciendo code reviews y organizando tu trabajo.
 
 ### Cadencia semanal
+
 Una semana puede parecer mucho tiempo, pero, parte de trabajar en un equipo significa tener en cuenta los costos de coordinación. Recordemos nuestro objetivo de hacer un demo en la url de producción los domingos para ver cómo debemos organizar nuestra semana.
+
 - Lunes, Martes y Miércoles - Realizar la tarea, investigar si es necesario y pair programming
 - Jueves - Completar la tarea y pedir feedback al otro equipo
 - Viernes - Responder y dar feedback en los PRs y pedir feedback de los mentores
 - Sábado - Responder al feedback de los mentores
 - Domingo - Demo en producción!
-Ya hemos visto muchos cohortes antes del suyo, por eso, nuestro consejo es enfocar su trabajo en los primeros días de la semana. ¡Algunas historias son más complicadas de lo que parecen!
+  Ya hemos visto muchos cohortes antes del suyo, por eso, nuestro consejo es enfocar su trabajo en los primeros días de la semana. ¡Algunas historias son más complicadas de lo que parecen!
 
 ### Weekly Syncs
+
 Cada domingo el equipo se reunirá en una llamada de Zoom para el Weekly Sync. Esta reunión siempre tiene un patrón familiar:
+
 - Demos/Discusión (15 minutos)
   - La llamada siempre empieza con cada pareja haciendo un demo rápido del feature que desarrollaron en “producción”, esto es la versión en vivo de la aplicación que están desarrollando para que el mundo la vea. Luego, haremos un demo del código que escribieron para que este feature funcionara. Esta es una práctica común en la mayoría de los equipos de software, esta es una muy buena oportunidad para que practiques hablar sobre tu trabajo. Esto puede ser muy útil en una entrevista de trabajo!
 - Módulo de aprendizaje (Cada dos semanas, 30 minutos)
@@ -105,12 +121,15 @@ Cada domingo el equipo se reunirá en una llamada de Zoom para el Weekly Sync. E
 - Retrospectiva (Cada dos semanas, 30 minutos)
   - En nuestros retros, compartiremos apreciaciones por otros miembros del equipo, hablaremos sobre qué salió bien desde una perspectiva del proceso y discutiremos qué podemos hacer para mejorar la forma en que trabajamos juntos.
 - Planning (15 minutos)
+
   - Los mentores se reunirán con las parejas para hablar sobre el trabajo de la siguiente semana
-  
- ### Recapitulemos
+
+### Recapitulemos
+
 Eso fue demasiado, ¿Cierto? Es muy probable (💯%) que hayamos olvidado u omitido algo importante, por favor, haz ruido en Slack cuando consideres necesario. Haremos lo mejor posible para desbloquearte. También, ¡habla con tu equipo si necesitas ayuda! Por último, trabaja en público para que todos se beneficien de tus preguntas.
 
 ### Hagamos un resumen de cómo será tu tiempo en The Collab Lab
+
 - En tu tiempo en The Collab Lab, ganarás experiencia trabajando en un equipo de software, liderado por personas que trabajan en la industria, en un proyecto estructurado de una forma muy cercana a lo que verás en muchas empresas.
 - Trabajaremos juntos por 8 semanas para construir un Smart Shopping List. Puedes ver un demo de lo que otros equipos construyeron [aquí](https://www.youtube.com/watch?v=uWgkwY_VBPo&feature=youtu.be)
 - Los equipos están conformados por 4 developers, 2 mentores y un mentor asistente.
@@ -119,7 +138,8 @@ Eso fue demasiado, ¿Cierto? Es muy probable (💯%) que hayamos olvidado u omit
 - Cada domingo durante el programa, el equipo tendrá un Weekly Sync donde los developers demostrarán el feature que construyeron durante la semana y un mentor liderará un learning module o el equipo participará en el Retrospective.
 
 ## ¿Qué sigue?
-Tu equipo arrancará el proyecto con el primer weekly sync en [cohort start date]. En la reunión se presentará un Learning Module sobre mejores prácticas de GIT y también nos aseguraremos que todos puedan colaborar en la aplicación. Después, agendaremos sesiones de pair programming con sus parejas para que resuelvan el issue de la semana.
+
+Tu equipo arrancará el proyecto con el primer weekly sync en {COHORT_START_DATE}. En la reunión se presentará un Learning Module sobre mejores prácticas de GIT y también nos aseguraremos que todos puedan colaborar en la aplicación. Después, agendaremos sesiones de pair programming con sus parejas para que resuelvan el issue de la semana.
 
 ## Let’s do this!
 

--- a/ORIENTATION-en.md
+++ b/ORIENTATION-en.md
@@ -1,6 +1,5 @@
 # The Collab Lab Orientation
 
-
 ## What is The Collab Lab?
 
 The Collab Lab exists to help early-career engineers gain experience working collaboratively on a software team by working remotely on real-world projects with other early-career developers.
@@ -9,27 +8,28 @@ The goal of this project is to work together to build a “smart” shopping lis
 
 Every team builds their app from the same set of instructions, but each comes out a little different, reflecting the personality of the group.
 
-:tv: &nbsp; Check out a video demo of the app team #6 made here: 
+:tv: &nbsp; Check out a video demo of the app team #6 made here:
 [![TCL Demo Video Screenshot](_resources/images/TCLDemoReadmePic.png)](https://youtu.be/uWgkwY_VBPo)
 
-## Who am I working with?  
+## Who am I working with?
 
-When new developers and mentors join the Collab Lab community they join a group of brilliant and supportive friends that stretch across the globe. Every quarter a new cohort starts that consists of several regionally-based teams. Those teams are comprised of four developers who collaborate to complete an app of their own and three mentors to help support them through the project. 
+When new developers and mentors join the Collab Lab community they join a group of brilliant and supportive friends that stretch across the globe. Every quarter a new cohort starts that consists of several regionally-based teams. Those teams are comprised of four developers who collaborate to complete an app of their own and three mentors to help support them through the project.
 
-## Why do we do what we do? 
+## Why do we do what we do?
 
 Knowing how to code is just one aspect of being a professional web developer. Another super important skill is knowing how to collaborate effectively on a software team—that’s where Collab Lab comes into play!
 
 ### Pair Programming:
+
 A portion of your dedicated hours each week will be spent [pair programming](https://www.microverse.org/blog/how-remote-pair-programming-works-and-why-it-can-change-your-life) with your partner for the week—this is where the most magical collaboration happens.
 
 Pair programming offers some really exciting opportunities to teach/learn from your partner, get a different perspective and/or insight on the issues you’re facing, and drive forward progress on your goals.
 
 There is no one “right” way to pair program, but in general you will meet with your partner on Zoom to work through the story or task you’ve chosen for that week. You’re encouraged to test out different approaches to pair programming to see what works best for your and your partners’ collaboration styles.
 
-## How does it all work?  
+## How does it all work?
 
-The project is organized in GitHub as a set of [user stories](https://www.mountaingoatsoftware.com/agile/user-stories), each with a description of the desired functionality as well as [acceptance criteria](https://www.leadingagile.com/2014/09/acceptance-criteria/ (AC)) that describe how you know whether the task or story is complete. You can find the stories on [the project board]({link to the cohort repo project board}) on GitHub. This is referred to as the “backlog” (the collection of stories) and represents the work needed to complete the project. 
+The project is organized in GitHub as a set of [user stories](https://www.mountaingoatsoftware.com/agile/user-stories), each with a description of the desired functionality as well as [acceptance criteria](https://www.leadingagile.com/2014/09/acceptance-criteria/ 'AC') that describe how you know whether the task or story is complete. You can find the stories on [the project board]({PROJECT_BOARD_URL}) on GitHub. This is referred to as the “backlog” (the collection of stories) and represents the work needed to complete the project.
 
 A task or story is “done” when the following are all true:
 
@@ -40,7 +40,7 @@ A task or story is “done” when the following are all true:
 
 Each week the team will split into pairs and each pair will be responsible for completing a single story from the backlog.
 
-At the end of the 8 week project all of the stories will be complete and we will have a beautifully functioning app that the team has collaboratively built! 
+At the end of the 8 week project all of the stories will be complete and we will have a beautifully functioning app that the team has collaboratively built!
 
 ### Coordination & communication
 
@@ -48,16 +48,15 @@ It’s super helpful both to yourself and the mentors for you to document your w
 
 One of the first things you & your pair buddy should do each week is create a [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) for your work. This allows you to have a conversation about the work right alongside the code. Coupled with questions and discussions about your approach in the issue itself, this is nice way of documenting your progress as you go.
 
-
 ### Slack
 
 Most of our team coordination will happen through [the Collab Lab Slack team](https://the-collab-lab.slack.com) and in particular your team channel.
 
 If you’re not already super familiar with Slack, no worries! Here are a couple of tips to help you use it like a pro!
 
-1. Threads threads threads! No seriously, threads! 😅  Threads are great because they do 2 really helpful things:
-    * They encapsulate conversations so the future you is able to find both the question and the answer in one place
-    * They keep notifications to a minimum, giving people the option of following a conversation or not.
+1. Threads threads threads! No seriously, threads! 😅 Threads are great because they do 2 really helpful things:
+   - They encapsulate conversations so the future you is able to find both the question and the answer in one place
+   - They keep notifications to a minimum, giving people the option of following a conversation or not.
 2. Speaking of notifications, tag people in when you need their attention. “`@stacie`, could you review this PR?” is better than “Can someone review this PR?” because the latter may not be seen for a while depending on the person’s notification settings. When you need to alert the whole channel to something use `@here`. We also have groups set up such as `@group-tcl-9` and `@group-tcl-9-mentors` as shortcuts to tagging in certain groups. Use them!
 3. Use GIFs and emoji liberally! Communicating via text can come across really dry. Don’t be afraid to communicate a little emotion along with that question about React hooks! 🤪
 
@@ -87,7 +86,7 @@ When you and your pair partner have working code that you believe is ready to be
 3. Incorporate feedback from the other pair team into your work until both you and they are satisfied the code is ready to be merged.
 4. Request that one of the mentors review the PR for final approval.
 5. Once approved, merge the PR into `main`. (Your code will be built and deployed to production automatically thanks to [Netlify](https://www.netlify.com/).)
-6. Check your work on the [production site]({link to cohort live site}).
+6. Check your work on the [production site]({PRODUCTION_URL}).
 7. Celebrate! 🥳
 
 ## When does everything happen?
@@ -106,36 +105,35 @@ A week sounds like a long time in some ways, but part of working on a team is ac
 
 Having watched many cohorts before yours, our advice is to front-load the work as much as possible in the first couple of days of each week. Some of the stories are trickier than they appear on the surface!
 
-### Weekly Syncs 
+### Weekly Syncs
 
-Every Sunday the team will gather for 1-hour on Zoom for a Weekly Sync. Those meetings will always follow a familiar pattern: 
+Every Sunday the team will gather for 1-hour on Zoom for a Weekly Sync. Those meetings will always follow a familiar pattern:
 
 - Demos/discussion (15 minutes)
   - The call will always start with each pair presenting a quick demo of the feature they built in “production”, the live version of the app that is deployed to the web for the world to see. This is followed by a concise walk-through of the code they wrote to build it. This is a common practice on most software teams that lets you practice talking about your work, which can come in handy in a job interview setting!
 - Learning module (30 minutes every other week)
-  - Presentations by mentors on topics that align with what your team is learning. Examples include git, code reviewing, pair programming, and communication for developers. 
+  - Presentations by mentors on topics that align with what your team is learning. Examples include git, code reviewing, pair programming, and communication for developers.
 - Retrospective (30 minutes every other week)
   - In our retros, we will share appreciations of our teammates, talk about what went well from a process perspective, and discuss what we could do to improve how we’re working together.
 - Planning (15 minutes)
   - Mentors meet with pairs to talk through approach to the upcoming week’s work (15 minutes)
 
-
 ## Let's recap!
 
 Whew, that was a lot, right? There’s a good chance (💯%) we’re forgetting or glossing over something important, so please be noisy on Slack as things come up. We will do our best to get you unstuck. Also, lean on each other for help as well! Finally, work in the open so everyone can benefit from your questions.
 
-**Let's run through a quick, high-level recap of what your time at The Collab Lab will look like:** 
+**Let's run through a quick, high-level recap of what your time at The Collab Lab will look like:**
 
-* During your time at The Collab Lab, you’ll gain experience working on a software team, led by people in the industry, on a project structured in a way very close to what you’d see at many companies.
-* We will spend 8 weeks working together to build a smart shopping list app. See a demo of the same app that a previous team built [here](https://www.youtube.com/watch?v=uWgkwY_VBPo&feature=youtu.be).
-* Collab Lab teams consist of 4 developers, 2 mentors, and 1 assistant mentor.
-* Each week, the team’s developers will break up into 2 pairs. Each pair will tackle a single issue from the project board in the team’s GitHub repo.
-* Developers will each spend about 5 hours per week working on the project. These hours include pair programming with weekly partners, researching, working with partner asynchronously on issues, creating pull requests, and doing code reviews.
-* Each Sunday during the program, the team will have a Weekly Sync where developers will demo the feature they built in the previous week and a mentor will lead a learning module or the team participate in a retrospective.
+- During your time at The Collab Lab, you’ll gain experience working on a software team, led by people in the industry, on a project structured in a way very close to what you’d see at many companies.
+- We will spend 8 weeks working together to build a smart shopping list app. See a demo of the same app that a previous team built [here](https://www.youtube.com/watch?v=uWgkwY_VBPo&feature=youtu.be).
+- Collab Lab teams consist of 4 developers, 2 mentors, and 1 assistant mentor.
+- Each week, the team’s developers will break up into 2 pairs. Each pair will tackle a single issue from the project board in the team’s GitHub repo.
+- Developers will each spend about 5 hours per week working on the project. These hours include pair programming with weekly partners, researching, working with partner asynchronously on issues, creating pull requests, and doing code reviews.
+- Each Sunday during the program, the team will have a Weekly Sync where developers will demo the feature they built in the previous week and a mentor will lead a learning module or the team participate in a retrospective.
 
-## What's Next? 
+## What's Next?
 
-Your team will kick off the project with your first weekly sync on {COHORT START DATE}. In the meeting we will present a Learning Module on git best practices and get everyone set up to collaborate on the app. Afterwards you will schedule pair programming sessions with your partner to work through your story of the week! 
+Your team will kick off the project with your first weekly sync on {COHORT_START_DATE}. In the meeting we will present a Learning Module on git best practices and get everyone set up to collaborate on the app. Afterwards you will schedule pair programming sessions with your partner to work through your story of the week!
 
 ### Let's Do This!
 

--- a/ORIENTATION-en.md
+++ b/ORIENTATION-en.md
@@ -29,7 +29,7 @@ There is no one “right” way to pair program, but in general you will meet wi
 
 ## How does it all work?
 
-The project is organized in GitHub as a set of [user stories](https://www.mountaingoatsoftware.com/agile/user-stories), each with a description of the desired functionality as well as [acceptance criteria](https://www.leadingagile.com/2014/09/acceptance-criteria/ 'AC') that describe how you know whether the task or story is complete. You can find the stories on [the project board]({PROJECT_BOARD_URL}) on GitHub. This is referred to as the “backlog” (the collection of stories) and represents the work needed to complete the project.
+The project is organized in GitHub as a set of [user stories](https://www.mountaingoatsoftware.com/agile/user-stories), each with a description of the desired functionality as well as [acceptance criteria](https://www.leadingagile.com/2014/09/acceptance-criteria/) that describe how you know whether the task or story is complete. You can find the stories on [the project board]({PROJECT_BOARD_URL}) on GitHub. This is referred to as the “backlog” (the collection of stories) and represents the work needed to complete the project.
 
 A task or story is “done” when the following are all true:
 

--- a/PROJECT-BRIEF.md
+++ b/PROJECT-BRIEF.md
@@ -4,11 +4,11 @@
 
 ### Locations for things
 
-- Site: {link to cohort live site}
-- Repo: {link to cohort repo}
-- Clone URL: `{clone URL}`
-- Issue list: {link to cohort repo issues}
-- Database: {link to cohort firebase database}
+- Site: {PRODUCTION_URL}
+- Repo: {REPO_URL}
+- Clone URL: {REPO_CLONE_URL}
+- Issue list: {PROJECT_BOARD_URL}
+- Google Cloud Console: {CONSOLE_URL}
 
 ### Project cadence & duration
 
@@ -18,42 +18,42 @@ Each week, the team of 4 developers will split into 2 pairs of 2 developers each
 
 Pairings will go as follows:
 
-#### Week 1, {start date - end date}
+#### Week 1, {DATES_WEEK_1}
 
-1. {Name} & {Name}
-2. {Name} & {Name}
+1. {DEV_1} & {DEV_2}
+2. {DEV_3} & {DEV_4}
 
-#### Week 2, {start date - end date}
+#### Week 2, {DATES_WEEK_2}
 
-1. {Name} & {Name}
-2. {Name} & {Name}
+1. {DEV_2} & {DEV_3}
+2. {DEV_1} & {DEV_4}
 
-#### Week 3, {start date - end date}
+#### Week 3, {DATES_WEEK_3}
 
-1. {Name} & {Name}
-2. {Name} & {Name}
+1. {DEV_3} & {DEV_1}
+2. {DEV_4} & {DEV_2}
 
-#### Week 4, {start date - end date}
+#### Week 4, {DATES_WEEK_4}
 
-1. {Name} & {Name}
-2. {Name} & {Name}
+1. {DEV_1} & {DEV_2}
+2. {DEV_3} & {DEV_4}
 
-#### Week 5, {start date - end date}
+#### Week 5, {DATES_WEEK_5}
 
-1. {Name} & {Name}
-2. {Name} & {Name}
+1. {DEV_2} & {DEV_3}
+2. {DEV_1} & {DEV_4}
 
-#### Week 6, {start date - end date}
+#### Week 6, {DATES_WEEK_6}
 
-1. {Name} & {Name}
-2. {Name} & {Name}
+1. {DEV_3} & {DEV_1}
+2. {DEV_4} & {DEV_2}
 
-#### Week 7, {start date - end date}
+#### Week 7, {DATES_WEEK_7}
 
-1. {Name} & {Name}
-2. {Name} & {Name}
+1. {DEV_1} & {DEV_2}
+2. {DEV_3} & {DEV_4}
 
-#### Week 8, {start date - end date}
+#### Week 8, {DATES_WEEK_8}
 
-1. {Name} & {Name}
-2. {Name} & {Name}
+1. {DEV_2} & {DEV_3}
+2. {DEV_1} & {DEV_4}

--- a/PROJECT-BRIEF.md
+++ b/PROJECT-BRIEF.md
@@ -8,7 +8,7 @@
 - Repo: {REPO_URL}
 - Clone URL: {REPO_CLONE_URL}
 - Issue list: {PROJECT_BOARD_URL}
-- Google Cloud Console: {CONSOLE_URL}
+- Database: {CONSOLE_URL}
 
 ### Project cadence & duration
 


### PR DESCRIPTION
## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|   ✓ | :scroll: Docs              |

## Description
This PR applies the new format for URLs and other data points that change from one team to the next.

There were a couple of data points that hadn't been named and I just updated them to the new format: {cohort start date} is now {COHORT_START_DATE}.

In addition I updated the `PROJECT-BRIEF.md` to match the formatting of the advanced project's version. I noticed that the Shopping List's project brief is truncated, but it looks like the Orientation guides are taking over that role.

There are also a few edits for consistency between the Spanish and English versions of the Orientation documents.