### PR TITLE
Add firebaserc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.firebaserc


### PR DESCRIPTION
Firebaserc is auto-generated when running firebase init. We can skip a step in the firebase setup by adding firebaserc to the template .gitignore.

To be specific, the step that can be refactored is [Step 3 in How to Setup CI/CD for project repos](https://www.notion.so/thecollablab/How-to-set-up-CI-CD-for-project-repos-3dc27b787d344218b74060d47532b0b6#480970f8d7b646258d7f86ade5fa9a04)