### PR TITLE
Remove project links from template

### DIFF
--- a/ORIENTACIÓN-es.md
+++ b/ORIENTACIÓN-es.md
@@ -29,7 +29,7 @@ No hay una sola manera de programar en pares, pero en general te encuentras con 
 
 ## ¿Como funciona todo?
 
-El proyecto está organizado en GitHub como un set de [historias de usuario](https://www.mountaingoatsoftware.com/agile/user-stories), cada una con una descripción de la funcionalidad deseada, y tambien con [los criterios de aceptación](https://www.leadingagile.com/2014/09/acceptance-criteria/) que describen como saber si la tarea o la historia estan listos. Puedes encontrar las historias de usuario en [el board del proyecto]({PROJECT_BOARD_URL}) en GitHub. Esta colección de historias de usuario se llama el “backlog” y representa el trabajo necesario para terminar el proyecto.
+El proyecto está organizado en GitHub como un set de [historias de usuario](https://www.mountaingoatsoftware.com/agile/user-stories), cada una con una descripción de la funcionalidad deseada, y tambien con [los criterios de aceptación](https://www.leadingagile.com/2014/09/acceptance-criteria/) que describen como saber si la tarea o la historia estan listos. Puedes encontrar las historias de usuario en el board del proyecto en GitHub. Esta colección de historias de usuario se llama el “backlog” y representa el trabajo necesario para terminar el proyecto.
 
 Una tarea o historia está “lista”/”done” cuando lo siguente está implementado:
 
@@ -92,7 +92,7 @@ Cuando tu y tu pareja de trabajo tengan codigo funcional y creen que esta listo 
 3. Incorpora el feedback del otro equipo en tu trabajo hasta que todes estan satisfechos que el codigo está listo para mergear
 4. Pedele un code review a una de las mentoras
 5. Ya aprobado, mergea el PR a `main`. (Tu codigo hace el build y se deploya a produccion automáticamente usando [Firebase Hosting](https://firebase.google.com/docs/hosting).)
-6. Revisa tu trabajo en [producción]({PRODUCTION_URL})
+6. Revisa tu trabajo en producción
 7. Celebra!
 
 ## ¿Cuándo sucede todo?

--- a/ORIENTATION-en.md
+++ b/ORIENTATION-en.md
@@ -29,7 +29,7 @@ There is no one “right” way to pair program, but in general you will meet wi
 
 ## How does it all work?
 
-The project is organized in GitHub as a set of [user stories](https://www.mountaingoatsoftware.com/agile/user-stories), each with a description of the desired functionality as well as [acceptance criteria](https://www.leadingagile.com/2014/09/acceptance-criteria/) that describe how you know whether the task or story is complete. You can find the stories on [the project board]({PROJECT_BOARD_URL}) on GitHub. This is referred to as the “backlog” (the collection of stories) and represents the work needed to complete the project.
+The project is organized in GitHub as a set of [user stories](https://www.mountaingoatsoftware.com/agile/user-stories), each with a description of the desired functionality as well as [acceptance criteria](https://www.leadingagile.com/2014/09/acceptance-criteria/) that describe how you know whether the task or story is complete. You can find the stories on the project board on GitHub. This is referred to as the “backlog” (the collection of stories) and represents the work needed to complete the project.
 
 A task or story is “done” when the following are all true:
 
@@ -86,7 +86,7 @@ When you and your pair partner have working code that you believe is ready to be
 3. Incorporate feedback from the other pair team into your work until both you and they are satisfied the code is ready to be merged.
 4. Request that one of the mentors review the PR for final approval.
 5. Once approved, merge the PR into `main`. (Your code will be built and deployed to production automatically thanks to [Firebase Hosting](https://firebase.google.com/docs/hosting).)
-6. Check your work on the [production site]({PRODUCTION_URL}).
+6. Check your work on the production site.
 7. Celebrate! 🥳
 
 ## When does everything happen?


### PR DESCRIPTION
Removed the links to project/production pages from the orientation pages.  We're not updating them as part of the automation and the relevant links can be found in the project-brief.  